### PR TITLE
Add support for polygonal objects in NOR

### DIFF
--- a/R/read_arena.R
+++ b/R/read_arena.R
@@ -455,16 +455,10 @@ read_arena = function(filename, description = NULL){
 			stop(paste0("At least one of 'object.1' or 'novel.object.1' must be specified. Please check the arena file '", filename, "'."))
 		}else if(count.object.1 == 1){ # Old object.
 			raw.object.1 = unlist(strsplit(description$object.1, "\\s+"))
-			object.1.coordinates = unlist(c(square_transform(as.numeric(raw.object.1[2]), as.numeric(raw.object.1[3]), transform.model),
-			square_transform(as.numeric(raw.object.1[4]), as.numeric(raw.object.1[5]), transform.model),
-			square_transform(as.numeric(raw.object.1[6]), as.numeric(raw.object.1[7]), transform.model),
-			square_transform(as.numeric(raw.object.1[8]), as.numeric(raw.object.1[9]), transform.model)))
+			object.1.coordinates = transform_object(raw.object.1, transform.model)
 		}else if(count.object.1 == 2){ # New object.
 			raw.object.1 = unlist(strsplit(description$novel.object.1, "\\s+"))
-			object.1.coordinates = unlist(c(square_transform(as.numeric(raw.object.1[2]), as.numeric(raw.object.1[3]), transform.model),
-			square_transform(as.numeric(raw.object.1[4]), as.numeric(raw.object.1[5]), transform.model),
-			square_transform(as.numeric(raw.object.1[6]), as.numeric(raw.object.1[7]), transform.model),
-			square_transform(as.numeric(raw.object.1[8]), as.numeric(raw.object.1[9]), transform.model)))
+			object.1.coordinates = transform_object(raw.object.1, transform.model)
 			object.1.is.novel = TRUE
 		}else if(count.object.1 == 3){
 			stop(paste0("Only one of 'object.1' or 'novel.object.1' may be specified. Please check the arena file '", filename, "'."))
@@ -474,16 +468,10 @@ read_arena = function(filename, description = NULL){
 			stop(paste0("At least one of 'object.2' or 'novel.object.2' must be specified. Please check the arena file '", filename, "'."))
 		}else if(count.object.2 == 1){ # Old object.
 			raw.object.2 = unlist(strsplit(description$object.2, "\\s+"))
-			object.2.coordinates = unlist(c(square_transform(as.numeric(raw.object.2[2]), as.numeric(raw.object.2[3]), transform.model),
-			square_transform(as.numeric(raw.object.2[4]), as.numeric(raw.object.2[5]), transform.model),
-			square_transform(as.numeric(raw.object.2[6]), as.numeric(raw.object.2[7]), transform.model),
-			square_transform(as.numeric(raw.object.2[8]), as.numeric(raw.object.2[9]), transform.model)))
+			object.2.coordinates = transform_object(raw.object.2, transform.model)
 		}else if(count.object.2 == 2){ # New object.
 			raw.object.2 = unlist(strsplit(description$novel.object.2, "\\s+"))
-			object.2.coordinates = unlist(c(square_transform(as.numeric(raw.object.2[2]), as.numeric(raw.object.2[3]), transform.model),
-			square_transform(as.numeric(raw.object.2[4]), as.numeric(raw.object.2[5]), transform.model),
-			square_transform(as.numeric(raw.object.2[6]), as.numeric(raw.object.2[7]), transform.model),
-			square_transform(as.numeric(raw.object.2[8]), as.numeric(raw.object.2[9]), transform.model)))
+			object.2.coordinates = transform_object(raw.object.2, transform.model)
 			object.2.is.novel = TRUE
 		}else if(count.object.2 == 3){
 			stop(paste0("Only one of 'object.2' or 'novel.object.2' may be specified. Please check the arena file '", filename, "'."))

--- a/R/shapes.R
+++ b/R/shapes.R
@@ -106,3 +106,34 @@ spin = function(x, y, angle){
 	)
 }
 
+transform_object = function(raw.obj, model) {
+	# Transform all points of a raw object by calling `square_transform` on all its points
+
+	# Remove the object type to get just the coordinates
+	raw.obj.coords = raw.obj[-1]
+
+	# If specifying a polygon, make sure there is an even number of coords (as x,y pairs)
+	if ((length(raw.obj.coords) >= 8) && (length(raw.obj.coords) %% 2 != 0)) {
+		stop("Please provide an even number of coordinates for the object.")
+	}
+
+	# Count the number of points and round it up to 4 so we always end up with a vector
+	# of at least 8 coordinates (even if they are NA)
+	n_points = ceiling(length(raw.obj.coords)/2)
+	if (n_points <= 4) n_points = 4;
+
+	# Perform the transformation to end up with a named vector
+	transformed.obj.coords = unlist(
+		mapply(
+			function(x, y) square_transform(as.numeric(x), as.numeric(y), model),
+			raw.obj.coords[seq(1, by = 2, length.out = n_points)], raw.obj.coords[seq(2, by = 2, length.out = n_points)],
+			SIMPLIFY = TRUE, USE.NAMES = FALSE
+		)
+	)
+
+	# Set "x" and "y" names
+	obj.coords = setNames(transformed.obj.coords, rep(c("x", "y"), length.out = length(transformed.obj.coords)))
+
+	# Return the result
+	return(obj.coords)
+}


### PR DESCRIPTION
Update to support NOR object specification as polygons with >4 points. Example of polygonal object specification in an arena text file (6 points), which always needs to have the `polygon x1 y1 x2 y2 x3 y3 x4 y4 x5 x5 (...)` format:
```
object.2 = polygon 741.7045593261719 246.5684509277344 757.9303894042969 249.91976165771484 797.8258666992188 210.4977264404297 790.0731201171875 194.2668609619141 770.2526245117188 194.2734832763672 737.9223327636719 230.29861450195312
novel.object.1 = polygon 892.5897216796875 87.07628631591797 923.9994201660156 86.71891403198242 932.1217651367188 63.780019760131836 928.904541015625 43.74013710021973 901.0473937988281 43.573068618774414 892.8282165527344 52.27064895629883
```

This change was done in three commits:

1. Added a universal transform method which supports any number of object points to replace `square_transform`,
2. Added a `polygon` function for storing polygonal objects (additionally, it always applies terra's [`convHull`](https://rspatial.github.io/terra/reference/convhull.html) function before returning the object in case points are specified out of order),
3. Updated NOR code to support arena text files with the `polygon` object specification.

This change implements functionality talked about recently in #8.
